### PR TITLE
add subject encoding for proper non-ascii symbols representation

### DIFF
--- a/email.go
+++ b/email.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"mime/multipart"
 	"mime/quotedprintable"
 	"net"
@@ -209,7 +210,7 @@ func (em *Sender) buildMessage(text string, params Params) (message string, err 
 	}
 	message = addHeader(message, "From", params.From)
 	message = addHeader(message, "To", strings.Join(params.To, ","))
-	message = addHeader(message, "Subject", params.Subject)
+	message = addHeader(message, "Subject", mime.BEncoding.Encode("utf-8", params.Subject))
 
 	withAttachments := len(params.Attachments) > 0
 	withInlineImg := len(params.InlineImages) > 0

--- a/email_test.go
+++ b/email_test.go
@@ -301,11 +301,11 @@ func TestEmail_buildMessageWithMIME(t *testing.T) {
 	msg, err := e.buildMessage("this is a test\n12345\n", Params{
 		From:    "from@example.com",
 		To:      []string{"to@example.com"},
-		Subject: "subj",
+		Subject: "non-ascii symbols: Привет",
 	})
 	require.NoError(t, err)
 	assert.Contains(t, msg, "Content-Transfer-Encoding: quoted-printable\nContent-Type: text/html; charset=\"UTF-8\"", msg)
-	assert.Contains(t, msg, "From: from@example.com\nTo: to@example.com\nSubject: subj\nMIME-version: 1.0", msg)
+	assert.Contains(t, msg, "From: from@example.com\nTo: to@example.com\nSubject: =?utf-8?b?bm9uLWFzY2lpIHN5bWJvbHM6INCf0YDQuNCy0LXRgg==?=\nMIME-version: 1.0", msg)
 	assert.Contains(t, msg, "\n\nthis is a test\r\n12345\r\n", msg)
 	assert.Contains(t, msg, "Date: ", msg)
 }


### PR DESCRIPTION
Originally done in https://github.com/umputun/remark42/pull/888 by @VeselovAlex.