### PR TITLE
fix wrong SMTP client host

### DIFF
--- a/email.go
+++ b/email.go
@@ -190,7 +190,7 @@ func (em *Sender) client() (c *smtp.Client, err error) {
 		return nil, fmt.Errorf("timeout connecting to %s: %w", srvAddress, err)
 	}
 
-	c, err = smtp.NewClient(conn, srvAddress)
+	c, err = smtp.NewClient(conn, em.host)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial: %w", err)
 	}


### PR DESCRIPTION
Before that fix, the "failed to auth to smtp smtp.eu.mailgun.org:587, wrong host name" error happens when one tries to use the library with StartTLS. Fixes problem in https://github.com/umputun/remark42/discussions/1359.

I've tested postmarkapp and SendGrid and Mailgun to verify it works: StartTLS works only after the change.