### PR TITLE
ci: review linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,17 +36,13 @@ linters:
     - govet
     - unconvert
     - megacheck
-    - structcheck
     - gas
     - gocyclo
     - dupl
     - misspell
     - unparam
-    - varcheck
-    - deadcode
     - typecheck
     - ineffassign
-    - varcheck
     - stylecheck
     - gochecknoinits
     - exportloopref
@@ -54,6 +50,7 @@ linters:
     - nakedret
     - gosimple
     - prealloc
+    - unused
   fast: false
   disable-all: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,6 @@ linters:
     - revive
     - govet
     - unconvert
-    - megacheck
     - gas
     - gocyclo
     - dupl

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,24 +31,24 @@ linters-settings:
 
 linters:
   enable:
-    - megacheck
-    - revive
-    - govet
-    - unconvert
-    - gas
-    - gocyclo
     - dupl
-    - misspell
-    - unparam
-    - typecheck
-    - ineffassign
-    - stylecheck
-    - gochecknoinits
     - exportloopref
+    - gas
+    - gochecknoinits
     - gocritic
-    - nakedret
+    - gocyclo
     - gosimple
+    - govet
+    - ineffassign
+    - megacheck
+    - misspell
+    - nakedret
     - prealloc
+    - revive
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
     - unused
   fast: false
   disable-all: true


### PR DESCRIPTION
- replace deprecated varcheck, deadcode, and structcheck linters by unused
- remove duplicated entity (megacheck linter) from linters list
