### PR TITLE
fix CI workflow caching by reordering checkout and setup-go steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,29 +11,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: set up go 1.19
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.19
-        id: go
-
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: set up go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.19"
+        id: go
 
       - name: build and test
         run: |
-          go get -v
           go test -timeout=60s -race -covermode=atomic -coverprofile=$GITHUB_WORKSPACE/profile.cov_tmp
           cat $GITHUB_WORKSPACE/profile.cov_tmp | grep -v "_mock.go" | grep -v "mocks"> $GITHUB_WORKSPACE/profile.cov
           go build -race
         env:
-          GO111MODULE: "on"
           TZ: "America/Chicago"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v5
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.60.2
+          version: v2.6
 
       - name: submit coverage
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,44 +1,15 @@
+version: "2"
 run:
   timeout: 5m
-  output:
-    format: tab
-  skip-dirs:
-    - vendor
-
-linters-settings:
-  govet:
-    enable:
-      - shadow
-  maligned:
-    suggest-new: true
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  misspell:
-    locale: US
-  lll:
-    line-length: 140
-  gocritic:
-    enabled-tags:
-      - performance
-      - style
-      - experimental
-    disabled-checks:
-      - wrapperFunc
-      - hugeParam
-      - rangeValCopy
-      - singleCaseSwitch
-      - ifElseChain
-
+  concurrency: 4
 linters:
+  default: none
   enable:
     - dupl
-    - exportloopref
     - gochecknoinits
     - gocritic
     - gocyclo
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
@@ -46,13 +17,37 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
-  fast: false
-  disable-all: true
+  settings:
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+        - hugeParam
+        - rangeValCopy
+        - singleCaseSwitch
+        - ifElseChain
+      enabled-tags:
+        - performance
+        - style
+        - experimental
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
 
-issues:
-  exclude-use-default: false
+  exclusions:
+    generated: lax
+    paths:
+      - vendor
+      - third_party
+      - builtin
+      - examples

--- a/email.go
+++ b/email.go
@@ -17,6 +17,7 @@ import (
 	"net/textproto"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -171,7 +172,7 @@ func (em *Sender) String() string {
 }
 
 func (em *Sender) client() (c *smtp.Client, err error) {
-	srvAddress := fmt.Sprintf("%s:%d", em.host, em.port)
+	srvAddress := net.JoinHostPort(em.host, strconv.Itoa(em.port))
 	// #nosec G402
 	tlsConf := &tls.Config{
 		InsecureSkipVerify: em.insecureSkipVerify, // #nosec G402

--- a/email_test.go
+++ b/email_test.go
@@ -21,8 +21,7 @@ import (
 func TestEmail_New(t *testing.T) {
 	logBuff := bytes.NewBuffer(nil)
 	logger := &mocks.LoggerMock{LogfFunc: func(format string, args ...interface{}) {
-		//nolint:gocritic // logger uses %v instead of %s using proposed fmt.Fprintf
-		_, _ = logBuff.WriteString(fmt.Sprintf(format, args...))
+		_, _ = fmt.Fprintf(logBuff, format, args...)
 	}}
 
 	s := NewSender("localhost", ContentType("text/html"), Port(123),


### PR DESCRIPTION
## Summary
- Move checkout step before setup-go to enable proper Go module caching
- Update actions/checkout to v4 and actions/setup-go to v5
- Update golangci-lint-action to v7 with version v2.6
- Migrate golangci-lint config from v1 to v2 format
- Use net.JoinHostPort for IPv6 compatibility
- Replace WriteString(fmt.Sprintf(...)) with fmt.Fprintf